### PR TITLE
Fix: resample signal before cutting/padding it

### DIFF
--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -1,4 +1,5 @@
 #Some codes are adopted from https://github.com/DCASE-REPO/DESED_task
+import librosa
 import torch
 from torch.utils.data import Dataset
 import torchaudio
@@ -136,8 +137,10 @@ class UnlabeledDataset(Dataset):
 
 
 def waveform_modification(filepath, pad_to, encoder):
-    wav, _ = sf.read(filepath)
+    wav, sr = sf.read(filepath)
     wav = to_mono(wav)
+    if sr != encoder.sr:
+        wav = librosa.resample(wav, orig_sr=sr, target_sr=encoder.sr)
     wav, pad_mask = pad_wav(wav, pad_to, encoder)
     wav = torch.from_numpy(wav).float()
     wav = normalize_wav(wav)


### PR DESCRIPTION
This pull request fixes a but in the loading of sound files with different sampling rate then the one the model was trained with.

if the audio has higher sampling rate the function
https://github.com/frednam93/FDY-SED/blob/5824ffb1f7806315f85946c27a7ec62b3bd3b46c/utils/dataset.py#L161
will simply cut it.

This pull requst uses Librosa to resample the signal into the correct sampling rate before padding/cutting it

